### PR TITLE
Moved handleTestEnd from "exit" event to "close"

### DIFF
--- a/bin/lib/index.js
+++ b/bin/lib/index.js
@@ -70,7 +70,7 @@ class default_1 {
             logger_1.logger("info", text);
             output = output + text;
         });
-        protractor.on("exit", (status) => {
+        protractor.on("close", (status) => {
             this.handleTestEnd(status, output);
         });
     }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -81,7 +81,7 @@ export default class{
       output = output + text;
     });
 
-    protractor.on("exit", (status) => {
+    protractor.on("close", (status) => {
       this.handleTestEnd(status, output);
     });
   }


### PR DESCRIPTION
In some situtaions, handleTestEnd function that was assigned to the "exit" event was called before test summary had been printed. Moving this function to "close" event should ensure that the process has done with the stdio.